### PR TITLE
Prepare library for 0.1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ virtualenv:
 
 sudo: required
 
+env: PLUGIN=upload
+
 services:
   - docker
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
-.. image:: https://travis-ci.org/ome/omero-cli-upload.svg?branch=master
-    :target: https://travis-ci.org/ome/omero-cli-upload
+.. image:: https://travis-ci.org/ome/omero-upload.svg?branch=master
+    :target: https://travis-ci.org/ome/omero-upload
 
-.. image:: https://badge.fury.io/py/omero-cli-upload.svg
-    :target: https://badge.fury.io/py/omero-cli-upload
+.. image:: https://badge.fury.io/py/omero-upload.svg
+    :target: https://badge.fury.io/py/omero-upload
 
 OMERO CLI upload
 ================
@@ -22,7 +22,7 @@ This section assumes that an OMERO.py is already installed.
 
 Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_::
 
-    $ pip install -U omero-cli-upload
+    $ pip install -U omero-upload
 
 License
 -------

--- a/setup.py
+++ b/setup.py
@@ -91,15 +91,15 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.1.0.dev1'
-url = "https://github.com/ome/omero-cli-upload/"
+version = '0.1.0'
+url = "https://github.com/ome/omero-upload/"
 
 setup(
     version=version,
     packages=['', 'omero.plugins'],
     package_dir={"": "src"},
-    name='omero-cli-upload',
-    description="Upload plugin for use in the OMERO CLI.",
+    name='omero-upload',
+    description="Upload library for use in the OMERO CLI.",
     long_description=read('README.rst'),
     long_description_content_type='text/x-rst',
     classifiers=[


### PR DESCRIPTION
- bump `version` to 0.1.0
- rename the project as `omero-upload` as per https://github.com/ome/omero-upload/pull/1#issuecomment-467820440