### PR TITLE
Remove unused imports

### DIFF
--- a/src/omero_cli_upload.py
+++ b/src/omero_cli_upload.py
@@ -25,12 +25,6 @@ import mimetypes
 
 from omero.cli import BaseControl
 
-try:
-    import hashlib
-    hash_sha1 = hashlib.sha1
-except Exception:
-    import sha
-    hash_sha1 = sha.new
 
 HELP = """Upload local files to the OMERO server"""
 RE = re.compile(r"\s*upload\s*")


### PR DESCRIPTION
Follow-up to https://github.com/ome/omero-upload/pull/1/files#r257979296
It turns out `hashlib.sha1` was never used (but presumably this wasn't flagged by flake8 due to the `hash_sha1 = ...`) statement. I've removed it.