### PR TITLE
Add Python3 support to the upload plugin

### DIFF
--- a/.omeroci/env
+++ b/.omeroci/env
@@ -1,0 +1,1 @@
+PLUGIN=upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
+---
 language: python
-
-virtualenv:
-  system_site_packages: true
-
 sudo: required
-
-env: PLUGIN=upload
 
 services:
   - docker
 
 before_install:
-  - git clone --recurse-submodules git://github.com/openmicroscopy/omero-test-infra .omero
+  - git clone git://github.com/ome/omero-test-infra .omero
 
 script:
   - .omero/cli-docker

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.2.1.dev'
+version = '0.3.dev1'
 url = "https://github.com/ome/omero-upload/"
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -127,5 +127,10 @@ setup(
     download_url='%s/v%s.tar.gz' % (url, version),
     keywords=['OMERO.CLI', 'plugin'],
     cmdclass={'test': PyTest},
-    tests_require=['pytest'],
+    install_requires=[
+        'omero-py>=5.6.dev4',
+        'future'],
+    tests_require=[
+        'pytest',
+        'mox3'],
 )

--- a/src/omero/plugins/upload.py
+++ b/src/omero/plugins/upload.py
@@ -11,5 +11,15 @@
 
 """
 
+
+import sys
+from omero.cli import CLI
 from omero_upload.cli import UploadControl, HELP
-register("upload", UploadControl, HELP) # noqa
+
+try:
+    register("upload", UploadControl, HELP) # noqa
+except NameError:
+    if __name__ == "__main__":
+        cli = CLI()
+        cli.register("upload", UploadControl, HELP)
+        cli.invoke(sys.argv[1:])

--- a/src/omero_upload/__init__.py
+++ b/src/omero_upload/__init__.py
@@ -17,7 +17,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from library import upload_ln_s
+from __future__ import absolute_import
+from .library import upload_ln_s
 __all__ = (
     'upload_ln_s',
 )

--- a/src/omero_upload/library.py
+++ b/src/omero_upload/library.py
@@ -17,10 +17,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from future import standard_library
+standard_library.install_aliases() # noqa
+from builtins import str
 from hashlib import sha1
 import logging
 import os
-from StringIO import StringIO
+from io import StringIO
 from uuid import uuid4
 import omero.clients
 from omero.gateway import BlitzGateway

--- a/test/integration/clitest/test_upload.py
+++ b/test/integration/clitest/test_upload.py
@@ -19,6 +19,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
 import pytest
 
 from omero.testlib.cli import CLITest

--- a/test/integration/test_lib_upload.py
+++ b/test/integration/test_lib_upload.py
@@ -19,6 +19,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
 import pytest
 import os
 

--- a/test/integration/test_lib_upload.py
+++ b/test/integration/test_lib_upload.py
@@ -43,7 +43,7 @@ class TestLibUpload(ITest):
         assert ofile.getHash() == 'f572d396fae9206628714fb2ce00f72e94f2258f'
         assert ofile.getSize() == 6
         with ofile.asFileObj() as fo:
-            assert fo.read() == txt
+            assert fo.read().decode('utf-8') == txt
 
         omero_path = os.path.join(
             omero_data_dir, 'Files', long_to_path(ofile.id))


### PR DESCRIPTION
- run `futurize -w -n .`
- fix Travis CI and consume the latest omero-test-infra
- add various dependencies to `setup.py`
- fix file encoding in `upload_ln` source and tests

Proposed tag `0.3.dev1`