### PR TITLE
CLI features: file annotation, in-place upload, mimetype

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,46 @@ Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_::
 
     $ pip install -U omero-upload
 
+Usage
+-----
+
+The plugin is called from the command-line using the `omero` command.
+
+To upload a single file::
+
+    $ omero upload <file>
+
+This command will create an `OriginalFile` on the server and return an output
+of type `OriginalFile:<id>`.
+
+To upload multiple files::
+
+    $ omero upload <file1> <file2>
+
+This command will create two `OriginalFile` and return an output of type `OriginalFile:<id1>,<id2>`
+
+By default, the mimetype will be guessed from the filename but it can be
+specified by using the `--mimetype` argument::
+
+    $ omero upload <file1> --mimetype 'test/csv'
+
+Files can be in-place uploaded into the OMERO.server via symlinked rather than
+being copied. This requires the command to be run on the OMERO.server itself
+from a user having write permissions to the OMERO data repository, similarly
+to the [in-place import](https://docs.openmicroscopy.org/omero/latest/sysadmins/in-place-import.html). To run an in-place upload, the `--data-dir` argument must be passed to
+specify the binary OMERO directory::
+
+    $ omero upload <file1> --data-dir /OMERO
+
+Instead of creating and returning a simple `OriginalFile` object, it is also possible to wrap the file within a `FileAnnotation` which can then be linked
+to other objects in the database. It is possible to specify the namespace of this `FileAnnotation` using the `--namespace` argument::
+
+
+    $ omero upload <file1> --wrap --namespace 'openmicroscopy.org/idr/analysis/original'
+
+This command will create an `OriginalFile` and a `FileAnnotation` and return
+an output of type `FileAnnotation:<id>`.
+
 Release process
 ---------------
 

--- a/src/omero_upload/cli.py
+++ b/src/omero_upload/cli.py
@@ -51,6 +51,8 @@ class UploadControl(BaseControl):
 
     def _configure(self, parser):
         parser.add_argument("file", nargs="+")
+        parser.add_argument(
+            "-m", "--mimetype", help="Mimetype of the file")
         parser.set_defaults(func=self.upload)
         parser.add_login_arguments()
 
@@ -60,11 +62,13 @@ class UploadControl(BaseControl):
         for file in args.file:
             if not path(file).exists():
                 self.ctx.die(500, "File: %s does not exist" % file)
-        for file in args.file:
+        for local_file in args.file:
             omero_format = UNKNOWN
-            if(mimetypes.guess_type(file) != (None, None)):
+            if args.mimetype:
+                omero_format = args.mimetype
+            elif (mimetypes.guess_type(file) != (None, None)):
                 omero_format = mimetypes.guess_type(file)[0]
-            obj = client.upload(file, type=omero_format)
+            obj = client.upload(local_file, type=omero_format)
             obj_ids.append(obj.id.val)
             self.ctx.set("last.upload.id", obj.id.val)
 

--- a/src/omero_upload/cli.py
+++ b/src/omero_upload/cli.py
@@ -58,7 +58,7 @@ class UploadControl(BaseControl):
             "-m", "--mimetype", help="Mimetype of the file")
         parser.add_argument(
             "--data-dir", type=str,
-            help="Path to the OMERO data directory. If passed will try to"
+            help="Path to the OMERO data directory. If passed will try to "
             "in-place upload into ManagedRepository")
         parser.add_argument(
             "--wrap", action="store_true",

--- a/src/omero_upload/cli.py
+++ b/src/omero_upload/cli.py
@@ -72,15 +72,15 @@ class UploadControl(BaseControl):
     def upload(self, args):
         client = self.ctx.conn(args)
         obj_ids = []
-        for file in args.file:
-            if not path(file).exists():
-                self.ctx.die(500, "File: %s does not exist" % file)
+        for local_file in args.file:
+            if not path(local_file).exists():
+                self.ctx.die(500, "File: %s does not exist" % local_file)
         for local_file in args.file:
             omero_format = UNKNOWN
             if args.mimetype:
                 omero_format = args.mimetype
-            elif (mimetypes.guess_type(file) != (None, None)):
-                omero_format = mimetypes.guess_type(file)[0]
+            elif (mimetypes.guess_type(local_file) != (None, None)):
+                omero_format = mimetypes.guess_type(local_file)[0]
             if args.data_dir:
                 obj = upload_ln_s(
                     client, local_file, args.data_dir, omero_format)

--- a/test/integration/clitest/test_upload.py
+++ b/test/integration/clitest/test_upload.py
@@ -43,38 +43,26 @@ class TestUpload(CLITest):
         self.cli.invoke(self.args, strict=True)
         return capfd.readouterr()[0]
 
-    def check_file_name(self, original_file, filename):
-        args = self.login_args() + ["obj", "get", original_file]
-        self.cli.invoke(args + ["name"], strict=True)
-        name = self.cli.get("tx.state").get_row(0)
-        assert filename.name == name
+    def get_objects(self, out):
+        objects = []
+        for i in out.split(":")[1].split(","):
+            objects.append(self.query.get(out.split(":")[0], int(i)))
+        return objects
 
-    def check_mimetype(self, original_file, expected_mimetype):
-        args = self.login_args() + ["obj", "get", original_file]
-        self.cli.invoke(args + ["mimetype"], strict=True)
-        mimetype = self.cli.get("tx.state").get_row(0)
-        assert mimetype == expected_mimetype
-
-    def check_file_path(self, original_file, is_link):
-        file_id = int(original_file.split(":")[1])
+    def is_symlink(self, original_file):
+        file_id = original_file.id.val
         omero_path = os.path.join("/OMERO", 'Files', long_to_path(file_id))
         assert os.path.exists(omero_path)
-        if is_link:
-            assert os.path.islink(omero_path)
-        else:
-            assert not os.path.islink(omero_path)
-
-    def check_namespace(self, original_file, expected_ns):
-        args = self.login_args() + ["obj", "get", original_file]
-        self.cli.invoke(args + ["ns"], strict=True)
-        ns = self.cli.get("tx.state").get_row(0)
-        assert ns == expected_ns
+        return os.path.islink(omero_path)
 
     def test_upload_single_file(self, capfd):
         f = create_path(suffix=".txt")
         self.args += [str(f)]
         out = self.upload(capfd)
-        self.check_file_name(out, f)
+        assert out.startswith("OriginalFile:")
+        objects = self.get_objects(out)
+        assert len(objects) == 1
+        assert objects[0].name.val == f.name
 
     @pytest.mark.parametrize('ln_s', [True, False])
     def test_upload_multiple_files(self, capfd, ln_s):
@@ -84,9 +72,17 @@ class TestUpload(CLITest):
         if ln_s:
             self.args += ["--data-dir", "/OMERO"]
         out = self.upload(capfd)
-        ids = out.split(":")[1].split(",")
-        self.check_file_name("OriginalFile:%s" % ids[0], f1)
-        self.check_file_name("OriginalFile:%s" % ids[1], f2)
+        assert out.startswith("OriginalFile:")
+        objects = self.get_objects(out)
+        assert len(objects) == 2
+        assert objects[0].name.val == f1.name
+        assert objects[1].name.val == f2.name
+        if ln_s:
+            assert self.is_symlink(objects[0])
+            assert self.is_symlink(objects[1])
+        else:
+            assert not self.is_symlink(objects[0])
+            assert not self.is_symlink(objects[1])
 
     def test_upload_bad_file(self, capfd):
         f1 = create_path(suffix=".txt")
@@ -99,8 +95,11 @@ class TestUpload(CLITest):
         f = create_path(suffix=".txt")
         self.args += [str(f)]
         out = self.upload(capfd)
-        self.check_file_name(out, f)
-        self.check_mimetype(out, "text/plain")
+        assert out.startswith("OriginalFile:")
+        objects = self.get_objects(out)
+        assert len(objects) == 1
+        assert objects[0].name.val == f.name
+        assert objects[0].mimetype.val == "text/plain"
 
     @pytest.mark.parametrize('ln_s', [True, False])
     def test_mimetype_argument(self, capfd, ln_s):
@@ -109,19 +108,58 @@ class TestUpload(CLITest):
         if ln_s:
             self.args += ["--data-dir", "/OMERO"]
         out = self.upload(capfd)
-        self.check_file_name(out, f)
-        self.check_mimetype(out, "text/csv")
+        assert out.startswith("OriginalFile:")
+        objects = self.get_objects(out)
+        assert len(objects) == 1
+        assert objects[0].name.val == f.name
+        assert objects[0].mimetype.val == "text/csv"
         if ln_s:
-            self.check_file_path(out, True)
+            assert self.is_symlink(objects[0])
         else:
-            self.check_file_path(out, False)
+            assert not self.is_symlink(objects[0])
 
+    @pytest.mark.parametrize('ln_s', [True, False])
     @pytest.mark.parametrize('ns', [None, 'foo'])
-    def test_file_annotation(self, capfd, ns):
+    @pytest.mark.parametrize('mimetype', [None, "text/csv"])
+    def test_file_annotation(self, capfd, ns, ln_s, mimetype):
         f = create_path(suffix=".txt")
         self.args += [str(f), "--wrap"]
         if ns is not None:
             self.args += ["--namespace", ns]
+        if ln_s:
+            self.args += ["--data-dir", "/OMERO"]
+        if mimetype:
+            self.args += ["--mimetype", mimetype]
         out = self.upload(capfd)
         assert out.startswith("FileAnnotation:")
-        self.check_namespace(out, ns)
+        objects = self.get_objects(out)
+        assert len(objects) == 1
+        if ns:
+            assert objects[0].ns.val == ns
+        else:
+            assert not objects[0].ns
+        original_file = self.query.get('OriginalFile', objects[0].file.id.val)
+        assert original_file.name.val == f.name
+        if mimetype:
+            assert original_file.mimetype.val == mimetype
+        else:
+            assert original_file.mimetype.val == "text/plain"
+        if ln_s:
+            assert self.is_symlink(original_file)
+        else:
+            assert not self.is_symlink(original_file)
+
+    def test_multiple_fileannotations(self, capfd):
+        f1 = create_path(suffix=".txt")
+        f2 = create_path(suffix=".txt")
+        self.args += [str(f1), str(f2), "--wrap"]
+        out = self.upload(capfd)
+        assert out.startswith("FileAnnotation:")
+        objects = self.get_objects(out)
+        assert len(objects) == 2
+        original_file = self.query.get('OriginalFile', objects[0].file.id.val)
+        assert original_file.name.val == f1.name
+        assert not self.is_symlink(original_file)
+        original_file = self.query.get('OriginalFile', objects[1].file.id.val)
+        assert original_file.name.val == f2.name
+        assert not self.is_symlink(original_file)

--- a/test/integration/clitest/test_upload.py
+++ b/test/integration/clitest/test_upload.py
@@ -47,6 +47,12 @@ class TestUpload(CLITest):
         name = self.cli.get("tx.state").get_row(0)
         assert filename.name == name
 
+    def check_mimetype(self, original_file, expected_mimetype):
+        args = self.login_args() + ["obj", "get", original_file]
+        self.cli.invoke(args + ["mimetype"], strict=True)
+        mimetype = self.cli.get("tx.state").get_row(0)
+        assert mimetype == expected_mimetype
+
     def test_upload_single_file(self, capfd):
         f = create_path(suffix=".txt")
         self.args += [str(f)]
@@ -68,3 +74,10 @@ class TestUpload(CLITest):
         self.args += [str(f1), str(f2)]
         with pytest.raises(NonZeroReturnCode):
             self.upload(capfd)
+
+    def test_guessed_mimetype(self, capfd):
+        f = create_path(suffix=".txt")
+        self.args += [str(f)]
+        out = self.upload(capfd)
+        self.check_file_name(out, f)
+        self.check_mimetype(out, "text/plain")

--- a/test/integration/clitest/test_upload.py
+++ b/test/integration/clitest/test_upload.py
@@ -81,3 +81,10 @@ class TestUpload(CLITest):
         out = self.upload(capfd)
         self.check_file_name(out, f)
         self.check_mimetype(out, "text/plain")
+
+    def test_mimetype_argument(self, capfd):
+        f = create_path(suffix=".txt")
+        self.args += [str(f), "--mimetype", "text/csv"]
+        out = self.upload(capfd)
+        self.check_file_name(out, f)
+        self.check_mimetype(out, "text/csv")


### PR DESCRIPTION
This PR adds a set of features to the upload CLI plugin. IT also fixes #9 by adding some usage information to the top-level readme.

This ports some of the features currently handled in the IDR [attach_file.py](https://github.com/dominikl/idr-utils/blob/a275576dd5330aab5cbbeb0f65f6302337b4cd8d/scripts/annotate/attach_file.py) script to this plugin. Shortly, it should be possible using the CLI to in-place upload a file with a specified mimetype and wrap it into a file annotation with a given namespace.

The CLI integration tests have been updated and reviewed to cover all combinations of arguments and check the attributes of the generated original files and file annotations.

Proposing to release this as `0.4.0` release given the API additions. There should be no breaking change and the former CLI behavior should be preserved.

/cc @dominikl