### PR TITLE
Remove mox3 from the test requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,6 @@ setup(
         'future'],
     python_requires='>=3',
     tests_require=[
-        'pytest',
-        'mox3'],
+        'omero-py>=5.17.0',
+        'pytest'],
 )

--- a/test/integration/clitest/test_upload.py
+++ b/test/integration/clitest/test_upload.py
@@ -26,7 +26,7 @@ import pytest
 from omero.testlib.cli import CLITest
 from omero.cli import NonZeroReturnCode
 from omero.plugins.obj import ObjControl
-from omero.plugins.upload import UploadControl
+from omero_upload.cli import UploadControl
 from omero.util.temp_files import create_path
 from omero.util import long_to_path
 


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/385

Tests requirements are updated to require OMERO.py 5.17.0 whichdeprecates the usage of mox3 for running integration tests
