### PR TITLE
Use pytest directly for running tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,8 +128,7 @@ setup(
     keywords=['OMERO.CLI', 'plugin'],
     cmdclass={'test': PyTest},
     install_requires=[
-        'omero-py>=5.6.0',
-        'future'],
+        'omero-py>=5.6.0'],
     python_requires='>=3',
     tests_require=[
         'omero-py>=5.17.0',

--- a/setup.py
+++ b/setup.py
@@ -18,69 +18,8 @@
 #
 #
 import os
-import sys
 
 from setuptools import setup
-from setuptools.command.test import test as test_command
-
-
-class PyTest(test_command):
-    user_options = [
-        ('test-path=', 't', "base dir for test collection"),
-        ('test-ice-config=', 'i',
-         "use specified 'ice config' file instead of default"),
-        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-        ('test-marker=', 'm', "only run tests including 'marker'"),
-        ('test-no-capture', 's', "don't suppress test output"),
-        ('test-failfast', 'x', "Exit on first error"),
-        ('test-verbose', 'v', "more verbose output"),
-        ('test-quiet', 'q', "less verbose output"),
-        ('junitxml=', None, "create junit-xml style report file at 'path'"),
-        ('pdb', None, "fallback to pdb on error"),
-        ]
-
-    def initialize_options(self):
-        test_command.initialize_options(self)
-        self.test_pythonpath = None
-        self.test_string = None
-        self.test_marker = None
-        self.test_path = 'test'
-        self.test_failfast = False
-        self.test_quiet = False
-        self.test_verbose = False
-        self.test_no_capture = False
-        self.junitxml = None
-        self.pdb = False
-        self.test_ice_config = None
-
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = [self.test_path]
-        if self.test_string is not None:
-            self.test_args.extend(['-k', self.test_string])
-        if self.test_marker is not None:
-            self.test_args.extend(['-m', self.test_marker])
-        if self.test_failfast:
-            self.test_args.extend(['-x'])
-        if self.test_verbose:
-            self.test_args.extend(['-v'])
-        if self.test_quiet:
-            self.test_args.extend(['-q'])
-        if self.junitxml is not None:
-            self.test_args.extend(['--junitxml', self.junitxml])
-        if self.pdb:
-            self.test_args.extend(['--pdb'])
-        self.test_suite = True
-        if 'ICE_CONFIG' not in os.environ:
-            os.environ['ICE_CONFIG'] = self.test_ice_config
-
-    def run_tests(self):
-        if self.test_pythonpath is not None:
-            sys.path.insert(0, self.test_pythonpath)
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 def read(fname):
@@ -126,7 +65,6 @@ setup(
     zip_safe=True,
     download_url='%s/v%s.tar.gz' % (url, version),
     keywords=['OMERO.CLI', 'plugin'],
-    cmdclass={'test': PyTest},
     install_requires=[
         'omero-py>=5.6.0'],
     python_requires='>=3',

--- a/src/omero_upload/__init__.py
+++ b/src/omero_upload/__init__.py
@@ -17,7 +17,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import
 from .library import upload_ln_s
 __all__ = (
     'upload_ln_s',

--- a/src/omero_upload/cli.py
+++ b/src/omero_upload/cli.py
@@ -25,13 +25,9 @@ import mimetypes
 from omero.cli import BaseControl
 from omero.model import FileAnnotationI, OriginalFileI
 from omero.rtypes import rstring
-from .library import upload_ln_s
+from omero_ext.path import path
 
-try:
-    from omero_ext.path import path
-except ImportError:
-    # Python 2
-    from path import path
+from .library import upload_ln_s
 
 
 HELP = """Upload local files to the OMERO server"""

--- a/src/omero_upload/library.py
+++ b/src/omero_upload/library.py
@@ -17,9 +17,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from future import standard_library
-standard_library.install_aliases() # noqa
-from builtins import str
 from hashlib import sha1
 import logging
 import os


### PR DESCRIPTION
Depends on https://github.com/ome/omero-test-infra/pull/68

- deprecate the `PyTest` command and use pytest directly to run the tests
- remove all usages of the `future` library